### PR TITLE
Fix some break changes

### DIFF
--- a/internal/hoop/connection.go
+++ b/internal/hoop/connection.go
@@ -12,23 +12,28 @@ import (
 )
 
 type Connection struct {
-	ID                  string            `json:"id"`
-	Name                string            `json:"name"`
-	Command             []string          `json:"command"`
-	Type                string            `json:"type"`
-	SubType             string            `json:"subtype"`
-	Secrets             map[string]string `json:"secret"`
-	AgentId             string            `json:"agent_id"`
-	Reviewers           []string          `json:"reviewers"`
-	RedactEnabled       bool              `json:"redact_enabled"`
-	RedactTypes         []string          `json:"redact_types"`
-	ConnectionTags      map[string]string `json:"connection_tags"`
-	AccessModeRunbooks  string            `json:"access_mode_runbooks"`
-	AccessModeExec      string            `json:"access_mode_exec"`
-	AccessModeConnect   string            `json:"access_mode_connect"`
-	AccessSchema        string            `json:"access_schema"`
-	GuardRailRules      []string          `json:"guardrail_rules"`
-	JiraIssueTemplateID string            `json:"jira_issue_template_id"`
+	ID                      string            `json:"id"`
+	Name                    string            `json:"name"`
+	Command                 []string          `json:"command"`
+	Type                    string            `json:"type"`
+	SubType                 string            `json:"subtype"`
+	Secrets                 map[string]string `json:"secret"`
+	AgentId                 string            `json:"agent_id"`
+	Reviewers               []string          `json:"reviewers"`
+	RedactEnabled           bool              `json:"redact_enabled"`
+	RedactTypes             []string          `json:"redact_types"`
+	ConnectionTags          map[string]string `json:"connection_tags"`
+	AccessModeRunbooks      string            `json:"access_mode_runbooks"`
+	AccessModeExec          string            `json:"access_mode_exec"`
+	AccessModeConnect       string            `json:"access_mode_connect"`
+	AccessSchema            string            `json:"access_schema"`
+	GuardRailRules          []string          `json:"guardrail_rules"`
+	JiraIssueTemplateID     string            `json:"jira_issue_template_id"`
+	AccessMaxDuration       *int              `json:"access_max_duration,omitempty"`
+	ForceApproveGroups      []string          `json:"force_approve_groups,omitempty"`
+	MandatoryMetadataFields []string          `json:"mandatory_metadata_fields,omitempty"`
+	MinReviewApprovals      *int              `json:"min_review_approvals,omitempty"`
+	ResourceName            string            `json:"resource_name,omitempty"`
 }
 
 func (c *Client) GetConnection(name string) (*Connection, error) {

--- a/internal/hoop/runbooks.go
+++ b/internal/hoop/runbooks.go
@@ -109,11 +109,19 @@ func (c *Client) doRunbookRequestWithBody(id string, repo RunbookRepo) (*Runbook
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
-		var resource RunbookRepo
+		var resource RunbookConfig
 		if err := json.NewDecoder(resp.Body).Decode(&resource); err != nil {
-			return nil, fmt.Errorf("failed decoding runbook repository resource, reason=%v", err)
+			return nil, fmt.Errorf("failed decoding runbook configuration response, reason=%v", err)
 		}
-		return &resource, nil
+		for _, r := range resource.Repositories {
+			if r.GitURL == repo.GitURL {
+				return &r, nil
+			}
+		}
+		if len(resource.Repositories) > 0 {
+			return &resource.Repositories[0], nil
+		}
+		return nil, fmt.Errorf("runbook repository %q not found in response", repo.GitURL)
 	}
 	return nil, validateErr(resp)
 }

--- a/internal/hoop/users.go
+++ b/internal/hoop/users.go
@@ -82,7 +82,7 @@ func (c *Client) UpdateUser(userEmail, status string, groups []string) (*User, e
 	user.Status = status
 	user.Groups = groups
 
-	apiURL := fmt.Sprintf("%s/users/%s", c.apiURL, userEmail)
+	apiURL := fmt.Sprintf("%s/users/%s", c.apiURL, user.ID)
 	body, err := json.Marshal(user)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal user, reason=%v", err)

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -31,22 +31,27 @@ func NewConnectionResource() resource.Resource {
 
 // connectionResourceModel maps the data source schema data.
 type connectionResourceModel struct {
-	ID                  types.String `tfsdk:"id"`
-	Name                types.String `tfsdk:"name"`
-	AgentID             types.String `tfsdk:"agent_id"`
-	Type                types.String `tfsdk:"type"`
-	Subtype             types.String `tfsdk:"subtype"`
-	Command             types.List   `tfsdk:"command"`
-	Secrets             types.Map    `tfsdk:"secrets"`
-	Reviewers           types.List   `tfsdk:"reviewers"`
-	RedactTypes         types.List   `tfsdk:"redact_types"`
-	Tags                types.Map    `tfsdk:"tags"`
-	AccessModeRunbooks  types.String `tfsdk:"access_mode_runbooks"`
-	AccessModeExec      types.String `tfsdk:"access_mode_exec"`
-	AccessModeConnect   types.String `tfsdk:"access_mode_connect"`
-	AccessSchema        types.String `tfsdk:"access_schema"`
-	GuardRailRules      types.List   `tfsdk:"guardrail_rules"`
-	JiraIssueTemplateID types.String `tfsdk:"jira_issue_template_id"`
+	ID                      types.String `tfsdk:"id"`
+	Name                    types.String `tfsdk:"name"`
+	AgentID                 types.String `tfsdk:"agent_id"`
+	Type                    types.String `tfsdk:"type"`
+	Subtype                 types.String `tfsdk:"subtype"`
+	Command                 types.List   `tfsdk:"command"`
+	Secrets                 types.Map    `tfsdk:"secrets"`
+	Reviewers               types.List   `tfsdk:"reviewers"`
+	RedactTypes             types.List   `tfsdk:"redact_types"`
+	Tags                    types.Map    `tfsdk:"tags"`
+	AccessModeRunbooks      types.String `tfsdk:"access_mode_runbooks"`
+	AccessModeExec          types.String `tfsdk:"access_mode_exec"`
+	AccessModeConnect       types.String `tfsdk:"access_mode_connect"`
+	AccessSchema            types.String `tfsdk:"access_schema"`
+	GuardRailRules          types.List   `tfsdk:"guardrail_rules"`
+	JiraIssueTemplateID     types.String `tfsdk:"jira_issue_template_id"`
+	AccessMaxDuration       types.Int64  `tfsdk:"access_max_duration"`
+	ForceApproveGroups      types.List   `tfsdk:"force_approve_groups"`
+	MandatoryMetadataFields types.List   `tfsdk:"mandatory_metadata_fields"`
+	MinReviewApprovals      types.Int64  `tfsdk:"min_review_approvals"`
+	ResourceName            types.String `tfsdk:"resource_name"`
 }
 
 // connectionResource is the data source implementation.
@@ -153,6 +158,31 @@ func (r *connectionResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"jira_issue_template_id": schema.StringAttribute{
 				Description: "The ID of the Jira issue template to be used for the connection.",
+				Optional:    true,
+				Validators:  NonEmptyStringValidator,
+			},
+			"access_max_duration": schema.Int64Attribute{
+				Description: "Maximum duration in seconds for JIT access sessions on this connection.",
+				Optional:    true,
+			},
+			"force_approve_groups": schema.ListAttribute{
+				Description: "Groups that can force approve reviews for this connection.",
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators:  NonEmptyListValidator,
+			},
+			"mandatory_metadata_fields": schema.ListAttribute{
+				Description: "Fields that must be present in the metadata for every session on this connection.",
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators:  NonEmptyListValidator,
+			},
+			"min_review_approvals": schema.Int64Attribute{
+				Description: "Minimum number of review approvals required to execute this connection.",
+				Optional:    true,
+			},
+			"resource_name": schema.StringAttribute{
+				Description: "Resource to which this connection belongs to. It will be created if it doesn't exist.",
 				Optional:    true,
 				Validators:  NonEmptyStringValidator,
 			},
@@ -402,6 +432,39 @@ func toConnectionResourceModel(ctx context.Context, state connectionResourceMode
 		state.JiraIssueTemplateID = types.StringNull()
 	}
 
+	if obj.AccessMaxDuration != nil {
+		state.AccessMaxDuration = types.Int64Value(int64(*obj.AccessMaxDuration))
+	} else {
+		state.AccessMaxDuration = types.Int64Null()
+	}
+
+	state.ForceApproveGroups, diags = types.ListValueFrom(ctx, types.StringType, obj.ForceApproveGroups)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if len(state.ForceApproveGroups.Elements()) == 0 {
+		state.ForceApproveGroups = types.ListNull(types.StringType)
+	}
+
+	state.MandatoryMetadataFields, diags = types.ListValueFrom(ctx, types.StringType, obj.MandatoryMetadataFields)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if len(state.MandatoryMetadataFields.Elements()) == 0 {
+		state.MandatoryMetadataFields = types.ListNull(types.StringType)
+	}
+
+	if obj.MinReviewApprovals != nil {
+		state.MinReviewApprovals = types.Int64Value(int64(*obj.MinReviewApprovals))
+	} else {
+		state.MinReviewApprovals = types.Int64Null()
+	}
+
+	state.ResourceName = types.StringValue(obj.ResourceName)
+	if state.ResourceName.ValueString() == "" {
+		state.ResourceName = types.StringNull()
+	}
+
 	return &state, nil
 }
 
@@ -422,6 +485,14 @@ func toConnectionHoopAPI(ctx context.Context, obj connectionResourceModel) (conn
 	if diags.HasError() {
 		return
 	}
+	forceApproveGroups, diags := convertListToStringSlice(ctx, obj.ForceApproveGroups)
+	if diags.HasError() {
+		return
+	}
+	mandatoryMetadataFields, diags := convertListToStringSlice(ctx, obj.MandatoryMetadataFields)
+	if diags.HasError() {
+		return
+	}
 
 	var connectionTags map[string]string
 	diags = obj.Tags.ElementsAs(ctx, &connectionTags, false)
@@ -435,23 +506,40 @@ func toConnectionHoopAPI(ctx context.Context, obj connectionResourceModel) (conn
 		return conn, diags
 	}
 
+	var accessMaxDuration *int
+	if !obj.AccessMaxDuration.IsNull() && !obj.AccessMaxDuration.IsUnknown() {
+		v := int(obj.AccessMaxDuration.ValueInt64())
+		accessMaxDuration = &v
+	}
+
+	var minReviewApprovals *int
+	if !obj.MinReviewApprovals.IsNull() && !obj.MinReviewApprovals.IsUnknown() {
+		v := int(obj.MinReviewApprovals.ValueInt64())
+		minReviewApprovals = &v
+	}
+
 	return hoop.Connection{
-		Name:                obj.Name.ValueString(),
-		Command:             command,
-		Type:                obj.Type.ValueString(),
-		SubType:             obj.Subtype.ValueString(),
-		Secrets:             secrets,
-		AgentId:             obj.AgentID.ValueString(),
-		Reviewers:           Reviewers,
-		RedactEnabled:       true,
-		RedactTypes:         redactTypes,
-		ConnectionTags:      connectionTags,
-		AccessModeRunbooks:  obj.AccessModeRunbooks.ValueString(),
-		AccessModeExec:      obj.AccessModeExec.ValueString(),
-		AccessModeConnect:   obj.AccessModeConnect.ValueString(),
-		AccessSchema:        obj.AccessSchema.ValueString(),
-		GuardRailRules:      guardRailRules,
-		JiraIssueTemplateID: obj.JiraIssueTemplateID.ValueString(),
+		Name:                    obj.Name.ValueString(),
+		Command:                 command,
+		Type:                    obj.Type.ValueString(),
+		SubType:                 obj.Subtype.ValueString(),
+		Secrets:                 secrets,
+		AgentId:                 obj.AgentID.ValueString(),
+		Reviewers:               Reviewers,
+		RedactEnabled:           true,
+		RedactTypes:             redactTypes,
+		ConnectionTags:          connectionTags,
+		AccessModeRunbooks:      obj.AccessModeRunbooks.ValueString(),
+		AccessModeExec:          obj.AccessModeExec.ValueString(),
+		AccessModeConnect:       obj.AccessModeConnect.ValueString(),
+		AccessSchema:            obj.AccessSchema.ValueString(),
+		GuardRailRules:          guardRailRules,
+		JiraIssueTemplateID:     obj.JiraIssueTemplateID.ValueString(),
+		AccessMaxDuration:       accessMaxDuration,
+		ForceApproveGroups:      forceApproveGroups,
+		MandatoryMetadataFields: mandatoryMetadataFields,
+		MinReviewApprovals:      minReviewApprovals,
+		ResourceName:            obj.ResourceName.ValueString(),
 	}, nil
 }
 

--- a/internal/provider/runbooks_configuration_resource_test.go
+++ b/internal/provider/runbooks_configuration_resource_test.go
@@ -29,7 +29,11 @@ func createFakeRunbookConfigurationTestServer() clientFunc {
 			}
 			resource.Repository = "fake-git-url-normalization" // no need to check this value for this tests
 			store[resourceID] = &resource
-			return httpTestOk(http.StatusCreated, &resource), nil
+			configResp := hoop.RunbookConfig{
+				ID:           uuid.NewString(),
+				Repositories: []hoop.RunbookRepo{resource},
+			}
+			return httpTestOk(http.StatusCreated, &configResp), nil
 		// GET /api/runbooks/configurations endpoint
 		case http.MethodGet:
 			var resource hoop.RunbookConfig
@@ -39,7 +43,7 @@ func createFakeRunbookConfigurationTestServer() clientFunc {
 				resource.Repositories = append(resource.Repositories, *repo)
 			}
 			return httpTestOk(http.StatusOK, &resource), nil
-		// PUT /api/datamasking-rules/{id} endpoint
+		// PUT /api/runbooks/configurations/{id} endpoint
 		case http.MethodPut:
 			var resource hoop.RunbookRepo
 			if err := json.NewDecoder(req.Body).Decode(&resource); err != nil {
@@ -59,7 +63,11 @@ func createFakeRunbookConfigurationTestServer() clientFunc {
 			}
 			resource.Repository = "fake-git-url-normalization" // no need to check this value for this tests
 			store[resourceID] = &resource
-			return httpTestOk(http.StatusOK, resource), nil
+			configResp := hoop.RunbookConfig{
+				ID:           uuid.NewString(),
+				Repositories: []hoop.RunbookRepo{resource},
+			}
+			return httpTestOk(http.StatusOK, &configResp), nil
 		case http.MethodDelete:
 			parts := strings.Split(req.URL.Path, "/")
 			id := parts[len(parts)-1]

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -207,7 +207,7 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	if err := r.client.DeleteUser(state.Email.ValueString()); err != nil {
+	if err := r.client.DeleteUser(state.ID.ValueString()); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting User",
 			fmt.Sprintf("Failed to delete user %q: %v", state.Email.ValueString(), err),

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -39,19 +39,26 @@ func createFakeUserTestServer() clientFunc {
 				return httpTestErr(http.StatusNotFound, `user with email %q not found`, userEmail), nil
 			}
 			return httpTestOk(http.StatusOK, usr), nil
-		// PUT /api/users/{user_email} endpoint
+		// PUT /api/users/{id} endpoint
 		case http.MethodPut:
 			var user hoop.User
 			if err := json.NewDecoder(req.Body).Decode(&user); err != nil {
 				return httpTestErr(http.StatusInternalServerError, `unable to decode request, reason: %v`, err), nil
 			}
 			parts := strings.Split(req.URL.Path, "/")
-			userEmail := parts[len(parts)-1]
-			if _, ok := store[userEmail]; !ok {
-				return httpTestErr(http.StatusNotFound, `user with email %q not found`, userEmail), nil
+			userID := parts[len(parts)-1]
+			var existingUser *hoop.User
+			for _, u := range store {
+				if u.ID == userID {
+					existingUser = u
+					break
+				}
 			}
-			user.ID = store[userEmail].ID
-			store[userEmail] = &user
+			if existingUser == nil {
+				return httpTestErr(http.StatusNotFound, `user with id %q not found`, userID), nil
+			}
+			user.ID = existingUser.ID
+			store[existingUser.Email] = &user
 			return httpTestOk(http.StatusOK, user), nil
 		case http.MethodDelete:
 			return &http.Response{


### PR DESCRIPTION
1. User API - PUT /users/{id} 
```
OpenAPI spec:
GET /users/{emailOrID} — accepts email OR id (backward compatible)
PUT /users/{id} — now requires the user ID (subject identifier)
DELETE /users/{id} — requires the user ID
```
2. Runbooks Configuration - Response Schema Changed (BREAKING)
```
OpenAPI spec response for both POST /runbooks/configurations and PUT /runbooks/configurations/{id} is openapi.RunbookConfigurationResponse:
{
  "id": "...",
  "org_id": "...",
  "repositories": [ { "git_url": "...", "repository": "...", ... } ],
  "created_at": "...",
  "updated_at": "..."
}
```

3. Connection - Missing New API Fields (INCOMPLETE)

Missing Field | Type | Description
-- | -- | --
access_max_duration | integer | Max duration for JIT access sessions
force_approve_groups | []string | Groups that can force-approve reviews
mandatory_metadata_fields | []string | Required metadata fields per session
min_review_approvals | integer | Minimum review approvals required
resource_name | string | Resource to which connection belongs

These are also missing read-only fields: default_database, managed_by, status.
While this doesn't cause runtime errors (Go's JSON decoder ignores unknown fields), it means:
The provider cannot manage these new attributes
On PUT updates, these fields will be silently reset to zero values since the Connection struct doesn't include them — the API will receive null/empty for these fields


Summary

Severity | Resource | Issue
-- | -- | --
CRITICAL | hoop_user | UpdateUser uses PUT /users/{email} but API now requires PUT /users/{id}
CRITICAL | hoop_user | Provider's Delete passes email to DeleteUser but API requires DELETE /users/{id}
BREAKING | hoop_runbook_configuration | POST/PUT responses return wrapped RunbookConfigurationResponse, but Go decodes as flat RunbookRepo — resulting in empty data
DEGRADED | hoop_connection | Missing 5 writable fields; PUT updtes may silently reset reset access_max_duration, force_approve_groups, mandatory_metadata_fields, min_review_approvals, resource_name to zero